### PR TITLE
Update ghostwriter/coding-standard to version dev-main#3ae3e7e

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -72,7 +72,9 @@
         "files": [
             "tests/bootstrap.php"
         ],
-        "exclude-from-classmap": ["/tests/"]
+        "exclude-from-classmap": [
+            "/tests/"
+        ]
     },
     "bin": [
         "bin/syntax"
@@ -96,15 +98,31 @@
     },
     "scripts": {
         "cache:clear": "rm -rf ./.cache/*",
-        "check": ["@cache:clear", "vendor/ghostwriter/coding-standard/tools/phar/composer validate", "@test"],
-        "docker": ["@docker:build", "@docker:run"],
+        "check": [
+            "@cache:clear",
+            "vendor/ghostwriter/coding-standard/tools/phar/composer validate",
+            "@test"
+        ],
+        "docker": [
+            "@docker:build",
+            "@docker:run"
+        ],
         "docker:build": "docker buildx build --pull --tag workspace .",
         "docker:run": "docker run -v $(PWD):/github/workspace -w=/github/workspace -e GITHUB_DEBUG=1 -e GITHUB_WORKSPACE=/github/workspace -e GITHUB_TOKEN=github-token -e SIGNING_SECRET_KEY=secret-key workspace",
         "git:submodule:update": "git submodule update --depth=1 --init --recursive --recommend-shallow --remote",
-        "infection": ["@xdebug", "vendor/ghostwriter/coding-standard/tools/phar/infection --min-covered-msi=0 --min-msi=0 --show-mutations --threads=max"],
+        "infection": [
+            "@xdebug",
+            "vendor/ghostwriter/coding-standard/tools/phar/infection --min-covered-msi=0 --min-msi=0 --show-mutations --threads=max"
+        ],
         "phpbench": "vendor/ghostwriter/coding-standard/tools/phar/phpbench run --report='extends:aggregate,cols:[benchmark,subject,revs,its,mem_peak,mode,rstdev]' --time-unit=milliseconds ./tests/Benchmark",
-        "phpunit": ["@xdebug", "vendor/ghostwriter/coding-standard/tools/phar/phpunit --do-not-cache-result --colors=always"],
-        "test": ["@phpunit", "@infection"],
+        "phpunit": [
+            "@xdebug",
+            "vendor/ghostwriter/coding-standard/tools/phar/phpunit --do-not-cache-result --colors=always"
+        ],
+        "test": [
+            "@phpunit",
+            "@infection"
+        ],
         "unused": "vendor/ghostwriter/coding-standard/tools/phar/composer-unused --no-interaction --ansi",
         "xdebug": "@putenv XDEBUG_MODE=coverage"
     }

--- a/composer.lock
+++ b/composer.lock
@@ -1126,12 +1126,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/ghostwriter/coding-standard.git",
-                "reference": "5095a3543c030ac7456d96a6b84917acddb7ff93"
+                "reference": "3ae3e7ee0910cfee6f848a5e2328672f378adcb6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/5095a3543c030ac7456d96a6b84917acddb7ff93",
-                "reference": "5095a3543c030ac7456d96a6b84917acddb7ff93",
+                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/3ae3e7ee0910cfee6f848a5e2328672f378adcb6",
+                "reference": "3ae3e7ee0910cfee6f848a5e2328672f378adcb6",
                 "shasum": ""
             },
             "require": {
@@ -1195,7 +1195,6 @@
                 "tools/phar/phpactor",
                 "tools/phar/phpbench",
                 "tools/phar/phpdocumentor",
-                "tools/phar/phpunit",
                 "tools/phar/psalm"
             ],
             "type": "composer-plugin",
@@ -1288,7 +1287,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-10-30T12:19:27+00:00"
+            "time": "2025-10-30T17:11:59+00:00"
         },
         {
             "name": "ghostwriter/config",


### PR DESCRIPTION
Updates the `ghostwriter/coding-standard` dependency from `dev-main#5095a35` to `dev-main#3ae3e7e`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`