### PR TITLE
Update ghostwriter/json to version 3.0.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,7 @@
         "ghostwriter/collection": "^2.0.0",
         "ghostwriter/container": "^5.0.1",
         "ghostwriter/event-dispatcher": "^5.0.3",
-        "ghostwriter/json": "^3.0.0",
+        "ghostwriter/json": "^3.0.1",
         "ghostwriter/option": "^2.0.0",
         "ghostwriter/result": "^2.0.0"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b44891e7c19007eacf97557eb32c1a60",
+    "content-hash": "a820332afdf6dadc0c6c3f13eac2848d",
     "packages": [
         {
             "name": "ghostwriter/case-converter",
@@ -261,27 +261,38 @@
         },
         {
             "name": "ghostwriter/json",
-            "version": "3.0.0",
+            "version": "3.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ghostwriter/json.git",
-                "reference": "233cb60e91ec3760ff849cf4b371fcc892819c6b"
+                "reference": "a672903f17a2f5e3a0359436ef7a10b3cf33462b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ghostwriter/json/zipball/233cb60e91ec3760ff849cf4b371fcc892819c6b",
-                "reference": "233cb60e91ec3760ff849cf4b371fcc892819c6b",
+                "url": "https://api.github.com/repos/ghostwriter/json/zipball/a672903f17a2f5e3a0359436ef7a10b3cf33462b",
+                "reference": "a672903f17a2f5e3a0359436ef7a10b3cf33462b",
                 "shasum": ""
             },
             "require": {
                 "ext-json": "*",
-                "php": "^8.3"
+                "php": "~8.4.0 || ~8.5.0"
             },
             "require-dev": {
+                "ext-xdebug": "*",
                 "ghostwriter/coding-standard": "dev-main",
-                "ghostwriter/psalm-plugin": "^0.1 || ^0.2 || ^1.0"
+                "ghostwriter/container": "^6.0.1",
+                "mockery/mockery": "^1.6.12",
+                "phpunit/phpunit": "^12.4.4",
+                "symfony/var-dumper": "^7.3.5"
             },
             "type": "library",
+            "extra": {
+                "ghostwriter": {
+                    "container": {
+                        "definition": "Ghostwriter\\Json\\Container\\JsonDefinition"
+                    }
+                }
+            },
             "autoload": {
                 "psr-4": {
                     "Ghostwriter\\Json\\": "src/"
@@ -289,7 +300,7 @@
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
-                "BSD-3-Clause"
+                "BSD-4-Clause"
             ],
             "authors": [
                 {
@@ -306,10 +317,9 @@
                 "json"
             ],
             "support": {
-                "docs": "https://github.com/ghostwriter/json",
-                "forum": "https://github.com/ghostwriter/json/discussions",
                 "issues": "https://github.com/ghostwriter/json/issues",
                 "rss": "https://github.com/ghostwriter/json/releases.atom",
+                "security": "https://github.com/ghostwriter/json/security/advisories/new",
                 "source": "https://github.com/ghostwriter/json"
             },
             "funding": [
@@ -318,7 +328,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-02-09T19:45:55+00:00"
+            "time": "2025-11-25T16:30:02+00:00"
         },
         {
             "name": "ghostwriter/option",


### PR DESCRIPTION
Updates the `ghostwriter/json` dependency from `3.0.0` to `3.0.1`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`