### PR TITLE
Update ghostwriter/coding-standard to version dev-main#31b146b

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -1223,12 +1223,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/ghostwriter/coding-standard.git",
-                "reference": "5aa6776aec7f387e133e595bcc9eb55aecc0a549"
+                "reference": "31b146b1293658542d1c8471c0c40c564e73fcad"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/5aa6776aec7f387e133e595bcc9eb55aecc0a549",
-                "reference": "5aa6776aec7f387e133e595bcc9eb55aecc0a549",
+                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/31b146b1293658542d1c8471c0c40c564e73fcad",
+                "reference": "31b146b1293658542d1c8471c0c40c564e73fcad",
                 "shasum": ""
             },
             "require": {
@@ -1402,7 +1402,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-12-15T07:16:13+00:00"
+            "time": "2025-12-15T10:11:12+00:00"
         },
         {
             "name": "ghostwriter/config",


### PR DESCRIPTION
Updates the `ghostwriter/coding-standard` dependency from `dev-main#5aa6776` to `dev-main#31b146b`.

This pull request changes the following file(s): 

- Update `composer.lock`