### PR TITLE
Update phpunit/phpunit to version 13.1.6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -50,7 +50,7 @@
         "ext-xdebug": "*",
         "ghostwriter/coding-standard": "dev-main",
         "mockery/mockery": "^1.6.12",
-        "phpunit/phpunit": "^13.1.5",
+        "phpunit/phpunit": "^13.1.6",
         "symfony/var-dumper": "^8.0.8"
     },
     "prefer-stable": true,

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b1947c32ebf7199b184c2073b165853e",
+    "content-hash": "a59c806e03044e91dfb23c95a486c68a",
     "packages": [
         {
             "name": "ghostwriter/case-converter",
@@ -620,12 +620,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/ghostwriter/coding-standard.git",
-                "reference": "38d0f3a56752c8903e83461cbfa68250da5b1dfc"
+                "reference": "75e0a8e06e1e271b384141143cdce701de48d3ef"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/38d0f3a56752c8903e83461cbfa68250da5b1dfc",
-                "reference": "38d0f3a56752c8903e83461cbfa68250da5b1dfc",
+                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/75e0a8e06e1e271b384141143cdce701de48d3ef",
+                "reference": "75e0a8e06e1e271b384141143cdce701de48d3ef",
                 "shasum": ""
             },
             "require": {
@@ -676,7 +676,7 @@
                 "ext-zlib": "*",
                 "mockery/mockery": "^1.6.12",
                 "php": "~8.4.0 || ~8.5.0",
-                "phpunit/phpunit": "^13.1.4",
+                "phpunit/phpunit": "^13.1.6",
                 "symfony/var-dumper": "^8.0.8"
             },
             "conflict": {
@@ -739,7 +739,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-04-15T07:55:22+00:00"
+            "time": "2026-04-17T14:32:36+00:00"
         },
         {
             "name": "hamcrest/hamcrest-php",
@@ -1495,16 +1495,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "13.1.5",
+            "version": "13.1.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "89adcba73441b38db31d5c0473b61e2907311db0"
+                "reference": "c3c414ea438e5a37d00697eaea43e6e05e201a42"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/89adcba73441b38db31d5c0473b61e2907311db0",
-                "reference": "89adcba73441b38db31d5c0473b61e2907311db0",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/c3c414ea438e5a37d00697eaea43e6e05e201a42",
+                "reference": "c3c414ea438e5a37d00697eaea43e6e05e201a42",
                 "shasum": ""
             },
             "require": {
@@ -1574,7 +1574,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/13.1.5"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/13.1.6"
             },
             "funding": [
                 {
@@ -1582,7 +1582,7 @@
                     "type": "other"
                 }
             ],
-            "time": "2026-04-16T04:58:40+00:00"
+            "time": "2026-04-17T12:52:50+00:00"
         },
         {
             "name": "sebastian/cli-parser",


### PR DESCRIPTION
Updates the `phpunit/phpunit` dependency from `13.1.5` to `13.1.6`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`