### PR TITLE
Update ghostwriter/container to version 7.0.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
         "ext-mbstring": "*",
         "ghostwriter/case-converter": "^2.2.2",
         "ghostwriter/collection": "^2.1.0",
-        "ghostwriter/container": "^7.0.0",
+        "ghostwriter/container": "^7.0.1",
         "ghostwriter/event-dispatcher": "^6.1.1",
         "ghostwriter/json": "^3.0.2",
         "ghostwriter/option": "^2.0.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "17e70e784636d4259aefb0d3237aa5d2",
+    "content-hash": "303e945517f05e6932a72111eb420510",
     "packages": [
         {
             "name": "ghostwriter/case-converter",
@@ -166,16 +166,16 @@
         },
         {
             "name": "ghostwriter/container",
-            "version": "7.0.0",
+            "version": "7.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ghostwriter/container.git",
-                "reference": "1931a1175deb24d0e5901a689054be8227144b3d"
+                "reference": "8e49e51d5558cb6482eac4da7170d75a765ee418"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ghostwriter/container/zipball/1931a1175deb24d0e5901a689054be8227144b3d",
-                "reference": "1931a1175deb24d0e5901a689054be8227144b3d",
+                "url": "https://api.github.com/repos/ghostwriter/container/zipball/8e49e51d5558cb6482eac4da7170d75a765ee418",
+                "reference": "8e49e51d5558cb6482eac4da7170d75a765ee418",
                 "shasum": ""
             },
             "require": {
@@ -241,7 +241,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-04-20T15:01:26+00:00"
+            "time": "2026-04-22T17:22:16+00:00"
         },
         {
             "name": "ghostwriter/event-dispatcher",


### PR DESCRIPTION
Updates the `ghostwriter/container` dependency from `7.0.0` to `7.0.1`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`